### PR TITLE
Add background music and sound effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
   <title>Daniela Persigue a Martin y Facundo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="css/styles.css">
+  <link rel="preload" as="audio" href="audio/main.mp3">
+  <link rel="preload" as="audio" href="audio/main2.mp3">
+  <link rel="preload" as="audio" href="audio/battle1.mp3">
+  <link rel="preload" as="audio" href="audio/battle2.mp3">
+  <link rel="preload" as="audio" href="audio/boss1.mp3">
+  <link rel="preload" as="audio" href="audio/boss2.mp3">
+  <link rel="preload" as="audio" href="audio/chact-select.mp3">
+  <link rel="preload" as="audio" href="audio/stage1.mp3">
 </head>
 <body>
   <div id="mainMenu" class="menu">

--- a/js/game.js
+++ b/js/game.js
@@ -34,6 +34,12 @@
       btnFullscreen: byId('btn-fullscreen')
     };
 
+    // --- Audio --------------------------------------------------------------
+    const mainMusic = new Audio('audio/main.mp3');
+    mainMusic.loop = true;
+
+    const coinSound = new Audio('audio/chact-select.mp3');
+
     // --- Estado del juego ----------------------------------------------------
     const ctx = UI.canvas.getContext('2d', { alpha: false });
     // Mejor para pixel art
@@ -233,6 +239,7 @@
       loadLevel(0);
       state.running = true;
       state.gameStarted = true;
+      mainMusic.play();
     });
 
     // --- Helpers de juego ------------------------------------------------------
@@ -284,6 +291,8 @@
       state.player.score += 100*n;
       setText(UI.coins, state.player.coins);
       setText(UI.score, state.player.score);
+      coinSound.currentTime = 0;
+      coinSound.play();
     }
 
     function clampFlight(){


### PR DESCRIPTION
## Summary
- Preload all audio tracks in index for smoother playback
- Add Audio objects for main theme and coin effect
- Start music on game launch and play coin sound when collecting coins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2637cd6c08324b4acd2170bbd573d