### PR TITLE
fix: define character scale

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -50,6 +50,10 @@
     const groundY = H - 92;
     const skyY = 12; // techo lógico para no salir por arriba
 
+    // Factor de escala para todos los personajes y sprites
+    // Permite ajustar fácilmente el tamaño sin modificar las imágenes originales
+    const CHAR_SCALE = 1;
+
 
     const state = {
       running: false,


### PR DESCRIPTION
## Summary
- define `CHAR_SCALE` constant to prevent runtime error

## Testing
- `node --check js/game.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a28d5de58c8324bd17c9342f0cbee5